### PR TITLE
feat(patterns): add Codex '▌ Working' pattern and debug visibility

### DIFF
--- a/tools/lib/patterns.js
+++ b/tools/lib/patterns.js
@@ -71,6 +71,12 @@ const CODEX_PATTERNS = [
     regex: /esc to interrupt/i,
     description: 'Codex working state detection',
     expectedState: 'WORKING'
+  },
+  {
+    pattern: '▌ Working',
+    regex: /▌\s*Working/i,
+    description: 'Codex explicit working indicator',
+    expectedState: 'WORKING'
   }
 ];
 
@@ -126,7 +132,8 @@ export function detectState(agent, line, recentOutput = '') {
       state: 'PENDING',
       details: cleanLine,
       confidence: 'high',
-      patternTests
+      patternTests,
+      detectionWindow: recentFewLines  // Add for debug visibility
     };
   }
   
@@ -139,7 +146,8 @@ export function detectState(agent, line, recentOutput = '') {
       state: 'WORKING',
       details: cleanLine,
       confidence: 'high',
-      patternTests
+      patternTests,
+      detectionWindow: recentLines  // Add for debug visibility
     };
   }
   
@@ -150,7 +158,8 @@ export function detectState(agent, line, recentOutput = '') {
     state: 'IDLE',
     details: cleanLine,
     confidence: idleConfidence,
-    patternTests
+    patternTests,
+    detectionWindow: recentLines  // Add for debug visibility
   };
 }
 


### PR DESCRIPTION
## Summary
- Add explicit '▌ Working' pattern for Codex WORKING state detection
- Add detectionWindow to all state returns for debugging visibility

## Changes
- Added new WORKING pattern for Codex when it shows "▌ Working" on screen
- Added `detectionWindow` field to all state returns for better debug visibility
- Preserved correct priority order (PENDING checked before WORKING)
- Maintained 10-line window for PENDING detection

## Why
The '▌ Working' pattern improves Codex state detection when it explicitly shows "Working" status. The debug visibility improvements help troubleshoot pattern matching issues.

## Testing
- Build passes successfully
- No breaking changes to existing pattern detection logic