### PR TITLE
fix(patterns): remove problematic block spinner pattern for Codex

### DIFF
--- a/tools/lib/patterns.js
+++ b/tools/lib/patterns.js
@@ -59,12 +59,6 @@ const CODEX_PATTERNS = [
     description: 'Codex negative command advisory',
     expectedState: 'PENDING'
   },
-  {
-    pattern: 'block spinner (▌▍▎▏▋▊█)',
-    regex: /(^|\n)\s*[▌▍▎▏▋▊█](?:\s|$)/m,
-    description: 'Codex spinner block detected',
-    expectedState: 'PENDING'
-  },
   // WORKING
   {
     pattern: 'esc to interrupt',


### PR DESCRIPTION
## Problem
The block spinner pattern `/(^|\n)\s*[▌▍▎▏▋▊█](?:\s|$)/m` was causing false PENDING detections in Codex because the `▌` character is Codex's standard prompt indicator that is **always present**, not a pending state indicator.

## Solution
Removed the problematic pattern that was matching on the vertical bar character alone.

## Impact
- Fixes false PENDING state detections when Codex is actually IDLE
- Retains all other valid PENDING patterns (Yes/No prompts, Allow command?, etc.)
- Improves accuracy of state detection for Codex

## Testing
- Build passes successfully
- The `▌` character alone will no longer trigger PENDING state
- Actual PENDING prompts (Yes/No, Allow command?) still work correctly