### PR TITLE
feat: implement mode-specific window sizing with fixed dimensions

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -13,8 +13,8 @@
     "windows": [
       {
         "title": "Tallr",
-        "width": 360,
-        "height": 600,
+        "width": 340,
+        "height": 400,
         "minWidth": 120,
         "minHeight": 60,
         "resizable": true,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -460,6 +460,10 @@ function App() {
                           // Dynamic width based on selection with flex-wrap constraints
                           const getColumnClasses = () => {
                             if (!selectedProjectId) {
+                              // Special case: if only one project, constrained width
+                              if (allProjectEntries.length === 1) {
+                                return 'flex-1 flex flex-col min-w-0 max-w-[350px] transition-all duration-300 ease-in-out';
+                              }
                               // No filter active - roughly 2 per row with equal distribution
                               return 'flex-1 flex flex-col min-w-0 basis-1/2 max-w-[calc(50%-4px)] transition-all duration-300 ease-in-out';
                             } else if (isSelected) {

--- a/src/components/TaskRow.tsx
+++ b/src/components/TaskRow.tsx
@@ -113,7 +113,7 @@ export default function TaskRow({
       <div
         className={cn(
           "flex flex-col justify-center gap-1 px-4 py-2 mb-2 rounded-lg bg-bg-card border border-border-primary cursor-pointer transition-all duration-150 animate-slideInUp relative overflow-hidden",
-          viewMode === 'simple' ? "min-h-[36px]" : "min-h-[44px]",
+          viewMode === 'simple' ? "min-h-[24px]" : "min-h-[28px]",
           "hover:border-border-secondary hover:bg-bg-hover",
           isTaskCompleted(task.state) && "opacity-70"
         )}


### PR DESCRIPTION
## Summary
- Implement fixed window dimensions for each view mode (simple, full, tally)
- Fix Tauri window resizing API usage with proper LogicalSize
- Reduce default window size for more compact UI

## Changes
- **Add dimension constants**: Clean configuration for all window sizes at top of useAdaptiveWindowSize
- **Fixed dimensions**: Simple (400x350), Full (400x400), Tally (400x110)
- **Fix Tauri API**: Use LogicalSize instead of problematic Physical sizing
- **Simplify calculations**: Replace complex dynamic height with fixed values
- **Compact TaskRows**: Reduce minimum heights for denser layout
- **Update defaults**: Set tauri.conf.json to 340x400 default

## Test plan
- [x] Verify simple mode is most compact (400x350)
- [x] Verify full mode uses standard size (400x400) 
- [x] Verify tally mode is very short (400x110)
- [x] Test smooth transitions between modes
- [x] Confirm sizing works correctly without console errors